### PR TITLE
Update ProtocolInfo.php

### DIFF
--- a/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
+++ b/src/pocketmine/network/mcpe/protocol/ProtocolInfo.php
@@ -39,9 +39,9 @@ interface ProtocolInfo{
 	/** Actual Minecraft: PE protocol version */
 	public const CURRENT_PROTOCOL = 486;
 	/** Current Minecraft PE version reported by the server. This is usually the earliest currently supported version. */
-	public const MINECRAFT_VERSION = 'v1.18.12';
+	public const MINECRAFT_VERSION = 'v1.18.10'; // same as 1.18.11 and 1.18.12
 	/** Version number sent to clients in ping responses. */
-	public const MINECRAFT_VERSION_NETWORK = '1.18.12';
+	public const MINECRAFT_VERSION_NETWORK = '1.18.10'; // 1.18.11 and 1.18.12 is the same with the protocol 486
 
 	public const LOGIN_PACKET = 0x01;
 	public const PLAY_STATUS_PACKET = 0x02;


### PR DESCRIPTION
the protocol of minecraft 1.18.10 is the same with 1.18.11 and 1.18.12 no need to change it!
